### PR TITLE
Python 3 Compatability

### DIFF
--- a/iterstuff/__init__.py
+++ b/iterstuff/__init__.py
@@ -1,3 +1,4 @@
-from lookahead import Lookahead
-from recipes import batch, repeatable_takewhile, chunked
+from __future__ import absolute_import
+from iterstuff.lookahead import Lookahead
+from iterstuff.recipes import batch, repeatable_takewhile, chunked
 

--- a/iterstuff/lookahead.py
+++ b/iterstuff/lookahead.py
@@ -1,3 +1,5 @@
+import six
+
 class Lookahead(object):
     """
     A Lookahead is a wrapper for any generator that lets you look at the
@@ -28,7 +30,7 @@ class Lookahead(object):
         """
         try:
             self._atstart = False
-            self._x = self._g.next()
+            self._x = six.advance_iterator(self._g)
         except StopIteration:
             self._x = None
             self._atend = True

--- a/iterstuff/recipes.py
+++ b/iterstuff/recipes.py
@@ -1,4 +1,5 @@
-from lookahead import Lookahead
+from __future__ import absolute_import
+from iterstuff.lookahead import Lookahead
 
 
 def repeatable_takewhile(predicate, iterable):

--- a/iterstuff/tests.py
+++ b/iterstuff/tests.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python
-import string
+from __future__ import absolute_import
+
+import six
+from six.moves import range
+from six.moves import map
+
+if six.PY2:
+    from string import lower
+else:
+    lower = str.lower
+
 from unittest import TestCase, main
 
-from recipes import batch, repeatable_takewhile, chunked
-from lookahead import Lookahead
+from iterstuff.recipes import batch, repeatable_takewhile, chunked
+from iterstuff.lookahead import Lookahead
 
 
 class LookaheadTest(TestCase):
@@ -65,44 +75,44 @@ class RecipeTests(TestCase):
         self.assertEqual(list(data), list('ghi'))
 
     def test_chunked(self):
-        r = map(list, chunked(""))
+        r = list(map(list, chunked("")))
         self.assertEqual(len(r), 0)
 
-        r = map(list, chunked("a"))
+        r = list(map(list, chunked("a")))
         self.assertEqual(len(r), 1)
         self.assertEqual(r[0][0], 'a')
         self.assertEqual(len(r[0]), 1)
 
-        r = map(list, chunked("aA", string.lower))
+        r = list(map(list, chunked("aA", lower)))
         self.assertEqual(len(r), 1)
         r2 = r[0]
         self.assertEqual(len(r2), 2)
         self.assertEqual(r2, ['a', 'A'])
 
-        r = map(list, chunked("ab"))
+        r = list(map(list, chunked("ab")))
         self.assertEqual(len(r), 2)
         self.assertEqual(r[0], ['a'])
         self.assertEqual(r[1], ['b'])
 
-        r = map(list, chunked("aabcc"))
+        r = list(map(list, chunked("aabcc")))
         self.assertEqual(len(r), 3)
         self.assertEqual(r[0], list("aa"))
         self.assertEqual(r[1], list("b"))
         self.assertEqual(r[2], list("cc"))
 
-        r = map(list, chunked("abBbb", string.lower))
+        r = list(map(list, chunked("abBbb", lower)))
         self.assertEqual(len(r), 2)
         self.assertEqual(r[0], ['a'])
         self.assertEqual(r[1], list("bBbb"))
 
-        r = map(list, chunked("abBbbC", string.lower))
+        r = list(map(list, chunked("abBbbC", lower)))
         self.assertEqual(len(r), 3)
         self.assertEqual(r[0], ['a'])
         self.assertEqual(r[1], list("bBbb"))
         self.assertEqual(r[2], ['C'])
 
     def test_batching(self):
-        seq = xrange(19)
+        seq = range(19)
         previous_list = None
         for batchiter in batch(seq, 3):
             x = list(batchiter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # The requirements file has the packages needed for building and
 # distributing.
 twine
-
+six
 


### PR DESCRIPTION
I added python 3 compatibility for the iterstuff module and tests by using the six module, a little bit of logic for the string.lower call in the tests file, and moving the imports to absolute paths. I ran the tests in python 2.7.8 and the Anaconda 2.1.0 python 3.4.1 interpreters.
